### PR TITLE
HB32 Vanilla Scheduler Extending the LLVM Generic Scheduler

### DIFF
--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -17,7 +17,6 @@ tablegen(LLVM RISCVGenSystemOperands.inc -gen-searchable-tables)
 add_public_tablegen_target(RISCVCommonTableGen)
 
 add_llvm_target(RISCVCodeGen
-  VanillaPasses.cpp
   RISCVAsmPrinter.cpp
   RISCVCallLowering.cpp
   RISCVExpandPseudoInsts.cpp
@@ -35,6 +34,7 @@ add_llvm_target(RISCVCodeGen
   RISCVTargetMachine.cpp
   RISCVTargetObjectFile.cpp
   RISCVTargetTransformInfo.cpp
+  HB32Scheduler.cpp
   )
 
 add_subdirectory(AsmParser)

--- a/llvm/lib/Target/RISCV/HB32Scheduler.cpp
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.cpp
@@ -1,4 +1,4 @@
-//===-- VanillaPasses.cpp - Vanilla Subtarget specific passes --------------===//
+//===-- HB32Scheduler.cpp - HB32 Subtarget specific passes --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Implements Vanilla Core specific passes.
+// Implements HB32 Vanilla Core specific passes.
 //
 //===----------------------------------------------------------------------===//
 
 #include "RISCV.h"
 #include "RISCVInstrInfo.h"
-#include "VanillaPasses.h"
+#include "HB32Scheduler.h"
 #include "llvm/Pass.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -24,30 +24,8 @@ using namespace llvm;
 
 #define DEBUG_TYPE "machine-scheduler"
 
-/// Example Machine Function Pass for Vanilla Core
-namespace {
-
-struct VanillaPass : public MachineFunctionPass {
-  static char ID;
-
-  VanillaPass(): MachineFunctionPass(ID) {}
-
-  bool runOnMachineFunction(MachineFunction &MF) override {
-    // Do nothing
-    return false;
-  }
-};
-
-}
-
-FunctionPass* llvm::createRISCVVanillaPass() {
-  return new VanillaPass();
-}
-
-char VanillaPass::ID = 0;
-
-/// Vanilla Core Scheduler
-SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
+/// HB32 Vanilla Core Scheduler
+SUnit *HB32Scheduler::pickNode (bool &IsTopNode) {
   if (DAG->top() == DAG->bottom()) {
     assert(Top.Available.empty() && Top.Pending.empty() &&
            Bot.Available.empty() && Bot.Pending.empty() && "ReadyQ garbage");
@@ -66,7 +44,7 @@ SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
         ArrayRef<MachineMemOperand*> memops = MI->memoperands();
         if (MI->mayLoad() &&
             !memops.empty() && memops[0]->getAddrSpace() == 1) {
-          LLVM_DEBUG(dbgs() << "VanillaScheduler bumping load ("
+          LLVM_DEBUG(dbgs() << "HB32Scheduler bumping load ("
                             << SUi->NodeNum << ") "
                             << *MI);
           SU = SUi;

--- a/llvm/lib/Target/RISCV/HB32Scheduler.cpp
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.cpp
@@ -32,7 +32,7 @@ static cl::opt<bool>
 
 /// Create custom scheduler if HB32Sched is enabled on the command line.
 ScheduleDAGInstrs *llvm::createHB32Scheduler(MachineSchedContext *C) {
-  if (!HB32Sched) {
+  if (HB32Sched) {
     return new ScheduleDAGMILive(C, std::make_unique<HB32Scheduler>(C));
   }
 

--- a/llvm/lib/Target/RISCV/HB32Scheduler.cpp
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.cpp
@@ -31,6 +31,7 @@ static cl::opt<bool>
 
 /// HB32 Vanilla Core Scheduler
 SUnit *HB32Scheduler::pickNode (bool &IsTopNode) {
+  // Run generic scheduler if HB32Sched is not enabled on command line
   if (!HB32Sched) {
     return GenericScheduler::pickNode(IsTopNode);
   }

--- a/llvm/lib/Target/RISCV/HB32Scheduler.cpp
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.cpp
@@ -1,4 +1,4 @@
-//===-- HB32Scheduler.cpp - HB32 Subtarget specific passes --------------===//
+//===-- HB32Scheduler.cpp - HB32 Subtarget specific passes -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -24,8 +24,17 @@ using namespace llvm;
 
 #define DEBUG_TYPE "machine-scheduler"
 
+static cl::opt<bool>
+    HB32Sched("hb32sched",
+              cl::desc("Enable HB32 Vanilla Core's custom scheduler"),
+              cl::init(false), cl::Hidden);
+
 /// HB32 Vanilla Core Scheduler
 SUnit *HB32Scheduler::pickNode (bool &IsTopNode) {
+  if (!HB32Sched) {
+    return GenericScheduler::pickNode(IsTopNode);
+  }
+
   if (DAG->top() == DAG->bottom()) {
     assert(Top.Available.empty() && Top.Pending.empty() &&
            Bot.Available.empty() && Bot.Pending.empty() && "ReadyQ garbage");

--- a/llvm/lib/Target/RISCV/HB32Scheduler.h
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.h
@@ -1,4 +1,4 @@
-//===-- VanillaPasses.h - Vanilla Subtarget specific passes ----------------===//
+//===-- HB32Scheduler.h - HB32 Subtarget specific passes ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Vanilla Core specific passes.
+// HB32 Vanilla Core specific passes.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,10 +17,10 @@
 
 namespace llvm {
 
-/// Example Machine Function Pass for Vanilla Core
-class VanillaScheduler : public GenericScheduler {
+/// Custom scheduler for HB32 Vanilla Core extending the generic scheduler
+class HB32Scheduler : public GenericScheduler {
 public:
-  VanillaScheduler(const MachineSchedContext *C): GenericScheduler(C) {}
+  HB32Scheduler(const MachineSchedContext *C): GenericScheduler(C) {}
 
 protected:
   SUnit *pickNode (bool &IsTopNode) override;

--- a/llvm/lib/Target/RISCV/HB32Scheduler.h
+++ b/llvm/lib/Target/RISCV/HB32Scheduler.h
@@ -17,6 +17,10 @@
 
 namespace llvm {
 
+/// Creates HB32 Scheduler. This creates a custom scheduler in place of default
+/// scheduler if corresponding flag is provided on the command line.
+ScheduleDAGInstrs *createHB32Scheduler(MachineSchedContext *C);
+
 /// Custom scheduler for HB32 Vanilla Core extending the generic scheduler
 class HB32Scheduler : public GenericScheduler {
 public:

--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -43,9 +43,6 @@ void initializeRISCVMergeBaseOffsetOptPass(PassRegistry &);
 FunctionPass *createRISCVExpandPseudoPass();
 void initializeRISCVExpandPseudoPass(PassRegistry &);
 
-FunctionPass *createRISCVVanillaPass();
-void initializeRISCVVanillaPass(PassRegistry &);
-
 InstructionSelector *createRISCVInstructionSelector(const RISCVTargetMachine &,
                                                     RISCVSubtarget &,
                                                     RISCVRegisterBankInfo &);

--- a/llvm/lib/Target/RISCV/RISCVSchedHB32.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedHB32.td
@@ -74,7 +74,7 @@ def : WriteRes<WriteLDH, [HB32UnitMem]>;
 def : WriteRes<WriteCSR, [HB32UnitALU]>;
 }
 
-let Latency = 20 in {
+let Latency = 2 in {
 def : WriteRes<WriteLDW, [HB32UnitMem]>;
 def : WriteRes<WriteFLD32, [HB32UnitMem]>;
 def : WriteRes<WriteFLD64, [HB32UnitMem]>;

--- a/llvm/lib/Target/RISCV/RISCVSchedHB32.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedHB32.td
@@ -12,7 +12,7 @@
 
 // Hammerblade machine model for scheduling and other instruction cost heuristics.
 def HB32Model : SchedMachineModel {
-  let MicroOpBufferSize = 0; // Explicitly set to zero since Rocket is in-order.
+  let MicroOpBufferSize = 0; // Explicitly set to zero since HB is in-order.
   let IssueWidth = 1;        // 1 micro-ops are dispatched per cycle.
   let LoadLatency = 2;
   let MispredictPenalty = 3; //TODO(Emily): need to determine this value

--- a/llvm/lib/Target/RISCV/RISCVSchedHB32.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedHB32.td
@@ -74,7 +74,7 @@ def : WriteRes<WriteLDH, [HB32UnitMem]>;
 def : WriteRes<WriteCSR, [HB32UnitALU]>;
 }
 
-let Latency = 2 in {
+let Latency = 20 in {
 def : WriteRes<WriteLDW, [HB32UnitMem]>;
 def : WriteRes<WriteFLD32, [HB32UnitMem]>;
 def : WriteRes<WriteFLD64, [HB32UnitMem]>;

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -142,7 +142,12 @@ TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
 
 ScheduleDAGInstrs *RISCVPassConfig::createMachineScheduler(
     MachineSchedContext *C) const {
-  return new ScheduleDAGMILive(C, std::make_unique<VanillaScheduler>(C));
+  if (C->MF->getSubtarget().getCPU().str() == "hb-rv32") {
+    return new ScheduleDAGMILive(C, std::make_unique<VanillaScheduler>(C));
+  }
+
+  // NULL selects default (generic) machine scheduler
+  return nullptr;
 }
 
 void RISCVPassConfig::addIRPasses() {

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -12,7 +12,7 @@
 
 #include "RISCVTargetMachine.h"
 #include "RISCV.h"
-#include "VanillaPasses.h"
+#include "HB32Scheduler.h"
 #include "RISCVTargetObjectFile.h"
 #include "RISCVTargetTransformInfo.h"
 #include "TargetInfo/RISCVTargetInfo.h"
@@ -143,7 +143,7 @@ TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
 ScheduleDAGInstrs *RISCVPassConfig::createMachineScheduler(
     MachineSchedContext *C) const {
   if (C->MF->getSubtarget().getCPU().str() == "hb-rv32") {
-    return new ScheduleDAGMILive(C, std::make_unique<VanillaScheduler>(C));
+    return new ScheduleDAGMILive(C, std::make_unique<HB32Scheduler>(C));
   }
 
   // NULL selects default (generic) machine scheduler
@@ -188,7 +188,6 @@ void RISCVPassConfig::addPreEmitPass2() {
   // possibility for other passes to break the requirements for forward
   // progress in the LR/SC block.
   addPass(createRISCVExpandPseudoPass());
-  addPass(createRISCVVanillaPass());
 }
 
 void RISCVPassConfig::addPreRegAlloc() {

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -12,6 +12,7 @@
 
 #include "RISCVTargetMachine.h"
 #include "RISCV.h"
+#include "VanillaPasses.h"
 #include "RISCVTargetObjectFile.h"
 #include "RISCVTargetTransformInfo.h"
 #include "TargetInfo/RISCVTargetInfo.h"
@@ -120,6 +121,9 @@ public:
     return getTM<RISCVTargetMachine>();
   }
 
+  ScheduleDAGInstrs *createMachineScheduler(
+      MachineSchedContext *C) const override;
+
   void addIRPasses() override;
   bool addInstSelector() override;
   bool addIRTranslator() override;
@@ -134,6 +138,11 @@ public:
 
 TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
   return new RISCVPassConfig(*this, PM);
+}
+
+ScheduleDAGInstrs *RISCVPassConfig::createMachineScheduler(
+    MachineSchedContext *C) const {
+  return new ScheduleDAGMILive(C, std::make_unique<VanillaScheduler>(C));
 }
 
 void RISCVPassConfig::addIRPasses() {

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -143,7 +143,7 @@ TargetPassConfig *RISCVTargetMachine::createPassConfig(PassManagerBase &PM) {
 ScheduleDAGInstrs *RISCVPassConfig::createMachineScheduler(
     MachineSchedContext *C) const {
   if (C->MF->getSubtarget().getCPU().str() == "hb-rv32") {
-    return new ScheduleDAGMILive(C, std::make_unique<HB32Scheduler>(C));
+    return createHB32Scheduler(C);
   }
 
   // NULL selects default (generic) machine scheduler

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -1,4 +1,4 @@
-//===-- VanillaPasses.cpp - Define TargetMachine for RISCV -----------===//
+//===-- VanillaPasses.cpp - Vanilla Subtarget specific passes --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -20,6 +20,8 @@
 
 using namespace llvm;
 
+#define DEBUG_TYPE "machine-scheduler"
+
 /// Example Machine Function Pass for Vanilla Core
 namespace {
 
@@ -44,7 +46,24 @@ char VanillaPass::ID = 0;
 
 /// Vanilla Core Scheduler
 SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
-  errs() << "Running Vanilla Scheduler\n";
+  SUnit* SU = Top.pickOnlyChoice(); 
 
+  //if (!SU) {
+  //  for(SU : Top.Available) {
+  //    if (!canIssueNow()) continue;
+  //    
+  //    
+  //    a
+  //  }
+
+  if (SU) {
+    LLVM_DEBUG(dbgs() << "Vanilla Scheduling SU(" << SU->NodeNum << ") "
+                      << *SU->getInstr());
+    Top.removeReady(SU);
+    IsTopNode = true;
+    return SU;
+  }
+
+  // Fallback to generic scheduler
   return GenericScheduler::pickNode(IsTopNode);
 }

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -11,15 +11,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "RISCV.h"
+#include "VanillaPasses.h"
 #include "llvm/Pass.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineFunction.h"
+#include "llvm/CodeGen/MachineScheduler.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
 /// Example Machine Function Pass for Vanilla Core
-
 namespace {
 
 struct VanillaPass : public MachineFunctionPass {
@@ -40,3 +41,10 @@ FunctionPass* llvm::createRISCVVanillaPass() {
 }
 
 char VanillaPass::ID = 0;
+
+/// Vanilla Core Scheduler
+SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
+  errs() << "Running Vanilla Scheduler\n";
+
+  return GenericScheduler::pickNode(IsTopNode);
+}

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -67,7 +67,7 @@ SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
         if (MI->mayLoad() &&
             !memops.empty() && memops[0]->getAddrSpace() == 1) {
           LLVM_DEBUG(dbgs() << "VanillaScheduler bumping load ("
-                            << SU->NodeNum << ") "
+                            << SUi->NodeNum << ") "
                             << *MI);
           SU = SUi;
           break;

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -11,11 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "RISCV.h"
+#include "RISCVInstrInfo.h"
 #include "VanillaPasses.h"
 #include "llvm/Pass.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineScheduler.h"
+#include "llvm/CodeGen/MachineMemOperand.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -46,24 +48,50 @@ char VanillaPass::ID = 0;
 
 /// Vanilla Core Scheduler
 SUnit *VanillaScheduler::pickNode (bool &IsTopNode) {
-  SUnit* SU = Top.pickOnlyChoice(); 
-
-  //if (!SU) {
-  //  for(SU : Top.Available) {
-  //    if (!canIssueNow()) continue;
-  //    
-  //    
-  //    a
-  //  }
-
-  if (SU) {
-    LLVM_DEBUG(dbgs() << "Vanilla Scheduling SU(" << SU->NodeNum << ") "
-                      << *SU->getInstr());
-    Top.removeReady(SU);
-    IsTopNode = true;
-    return SU;
+  if (DAG->top() == DAG->bottom()) {
+    assert(Top.Available.empty() && Top.Pending.empty() &&
+           Bot.Available.empty() && Bot.Pending.empty() && "ReadyQ garbage");
+    return nullptr;
   }
 
-  // Fallback to generic scheduler
-  return GenericScheduler::pickNode(IsTopNode);
+  SUnit *SU;
+
+  do {
+    SU = Top.pickOnlyChoice();
+
+    // Priorotize loads from address space 1
+    if (!SU) {
+      for(SUnit* SUi : Top.Available) {
+        MachineInstr* MI = SUi->getInstr();
+        ArrayRef<MachineMemOperand*> memops = MI->memoperands();
+        if (MI->mayLoad() &&
+            !memops.empty() && memops[0]->getAddrSpace() == 1) {
+          LLVM_DEBUG(dbgs() << "VanillaScheduler bumping load ("
+                            << SU->NodeNum << ") "
+                            << *MI);
+          SU = SUi;
+          break;
+        }
+      }
+    }
+
+    // Fallback to top-down policy of generic scheduler
+    if (!SU) {
+      CandPolicy NoPolicy;
+      TopCand.reset(NoPolicy);
+      pickNodeFromQueue(Top, NoPolicy, DAG->getTopRPTracker(), TopCand);
+      assert(TopCand.Reason != NoCand && "failed to find a candidate");
+      SU = TopCand.SU;
+    }
+    IsTopNode = true;
+  } while (SU->isScheduled);
+
+  if (SU->isTopReady())
+    Top.removeReady(SU);
+  if (SU->isBottomReady())
+    Bot.removeReady(SU);
+
+  LLVM_DEBUG(dbgs() << "Scheduling SU(" << SU->NodeNum << ") "
+                    << *SU->getInstr());
+  return SU;
 }

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -1,3 +1,15 @@
+//===-- VanillaPasses.cpp - Define TargetMachine for RISCV -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements Vanilla Core specific passes.
+//
+//===----------------------------------------------------------------------===//
+
 #include "RISCV.h"
 #include "llvm/Pass.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
@@ -5,6 +17,8 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
+
+/// Example Machine Function Pass for Vanilla Core
 
 namespace {
 
@@ -14,6 +28,7 @@ struct VanillaPass : public MachineFunctionPass {
   VanillaPass(): MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override {
+    // Do nothing
     return false;
   }
 };

--- a/llvm/lib/Target/RISCV/VanillaPasses.cpp
+++ b/llvm/lib/Target/RISCV/VanillaPasses.cpp
@@ -14,8 +14,6 @@ struct VanillaPass : public MachineFunctionPass {
   VanillaPass(): MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override {
-    errs() << "VanillaPass: ";
-    errs() << MF.getName() << "\n";
     return false;
   }
 };
@@ -27,4 +25,3 @@ FunctionPass* llvm::createRISCVVanillaPass() {
 }
 
 char VanillaPass::ID = 0;
-static RegisterPass<VanillaPass> X("vanilla", "Vanilla Pass");

--- a/llvm/lib/Target/RISCV/VanillaPasses.h
+++ b/llvm/lib/Target/RISCV/VanillaPasses.h
@@ -1,0 +1,31 @@
+//===-- VanillaPasses.h - Define TargetMachine for RISCV -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Vanilla Core specific passes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_POWERPC_VANILLASCHEDULER_H
+#define LLVM_LIB_TARGET_POWERPC_VANILLASCHEDULER_H
+
+#include "llvm/CodeGen/MachineScheduler.h"
+
+namespace llvm {
+
+/// Example Machine Function Pass for Vanilla Core
+class VanillaScheduler : public GenericScheduler {
+public:
+  VanillaScheduler(const MachineSchedContext *C): GenericScheduler(C) {}
+
+protected:
+  SUnit *pickNode (bool &IsTopNode) override;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_LIB_TARGET_POWERPC_VANILLASCHEDULER_H

--- a/llvm/lib/Target/RISCV/VanillaPasses.h
+++ b/llvm/lib/Target/RISCV/VanillaPasses.h
@@ -1,4 +1,4 @@
-//===-- VanillaPasses.h - Define TargetMachine for RISCV -----------===//
+//===-- VanillaPasses.h - Vanilla Subtarget specific passes ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Custom Scheduler for HB32 Subtarget. Can be enabled when with `hb32sched` option: 

`llc -mcpu=hb-rv32 -hb32sched <...>`