### PR TITLE
Dynamic load latency based on address spaces

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -79,6 +79,7 @@ const RegisterBankInfo *RISCVSubtarget::getRegBankInfo() const {
   return RegBankInfo.get();
 }
 
+/// Target specific adjustments to scheduler dependencies
 void RISCVSubtarget::adjustSchedDependency (SUnit *Def, SUnit *Use,
                                             SDep &Dep) const {
   MachineInstr *SrcInst = Def->getInstr();
@@ -86,6 +87,9 @@ void RISCVSubtarget::adjustSchedDependency (SUnit *Def, SUnit *Use,
     return;
 
   if (getCPU() == "hb-rv32") {
+    // For HammerBlade Vanilla Subtarget, remote addresses are assigned
+    // address space 1. Here, we conditionally ajdust the latency of loads
+    // to remote addresses by looking at address space of memory operands.
     ArrayRef<MachineMemOperand*> memops = SrcInst->memoperands();
     if (SrcInst->mayLoad() &&
         !memops.empty() && memops[0]->getAddrSpace() == 1) {

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -82,6 +82,8 @@ public:
     return &TSInfo;
   }
   bool enableMachineScheduler() const override { return true; }
+  void adjustSchedDependency (SUnit *Def, SUnit *Use, SDep &Dep
+                              ) const override;
   bool hasStdExtM() const { return HasStdExtM; }
   bool hasStdExtA() const { return HasStdExtA; }
   bool hasStdExtF() const { return HasStdExtF; }

--- a/llvm/test/CodeGen/RISCV/hb32-rem-load-sched.ll
+++ b/llvm/test/CodeGen/RISCV/hb32-rem-load-sched.ll
@@ -1,0 +1,51 @@
+; RUN: llc -march=riscv32 -mattr=+m,+a,+f -target-abi=ilp32f -mcpu=hb-rv32 \
+; RUN:    < %s | FileCheck %s
+
+define void @vec_add(i32 addrspace(1)* noalias nocapture %a,
+                     i32 addrspace(1)* noalias nocapture readonly %b) 
+                    nounwind {
+; CHECK-LABEL: vec_add:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lw  a6, 0(a1)
+; CHECK-NEXT:    lw  a7, 0(a0)
+; CHECK-NEXT:    lw  t0, 4(a1)
+; CHECK-NEXT:    lw  t1, 4(a0)
+; CHECK-NEXT:    lw  a2, 8(a1)
+; CHECK-NEXT:    lw  a3, 8(a0)
+; CHECK-NEXT:    lw  a1, 12(a1)
+; CHECK-NEXT:    lw  a4, 12(a0)
+; CHECK-NEXT:    add a5, a7, a6
+; CHECK-NEXT:    sw  a5, 0(a0)
+; CHECK-NEXT:    add a5, t1, t0
+; CHECK-NEXT:    sw  a5, 4(a0)
+; CHECK-NEXT:    add a2, a3, a2
+; CHECK-NEXT:    sw  a2, 8(a0)
+; CHECK-NEXT:    add a1, a4, a1
+; CHECK-NEXT:    sw  a1, 12(a0)
+; CHECK-NEXT:    ret
+entry:
+  %0 = load i32, i32 addrspace(1)* %b
+  %1 = load i32, i32 addrspace(1)* %a
+  %add = add nsw i32 %1, %0
+  store i32 %add, i32 addrspace(1)* %a
+  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %b, i32 1
+  %2 = load i32, i32 addrspace(1)* %arrayidx2
+  %arrayidx3 = getelementptr inbounds i32, i32 addrspace(1)* %a, i32 1
+  %3 = load i32, i32 addrspace(1)* %arrayidx3
+  %add4 = add nsw i32 %3, %2
+  store i32 %add4, i32 addrspace(1)* %arrayidx3
+  %arrayidx5 = getelementptr inbounds i32, i32 addrspace(1)* %b, i32 2
+  %4 = load i32, i32 addrspace(1)* %arrayidx5
+  %arrayidx6 = getelementptr inbounds i32, i32 addrspace(1)* %a, i32 2
+  %5 = load i32, i32 addrspace(1)* %arrayidx6
+  %add7 = add nsw i32 %5, %4
+  store i32 %add7, i32 addrspace(1)* %arrayidx6
+  %arrayidx8 = getelementptr inbounds i32, i32 addrspace(1)* %b, i32 3
+  %6 = load i32, i32 addrspace(1)* %arrayidx8
+  %arrayidx9 = getelementptr inbounds i32, i32 addrspace(1)* %a, i32 3
+  %7 = load i32, i32 addrspace(1)* %arrayidx9
+  %add10 = add nsw i32 %7, %6
+  store i32 %add10, i32 addrspace(1)* %arrayidx9
+  ret void
+}
+


### PR DESCRIPTION
- Adjusts the edge latency of schedule DAG when the source instruction is a load from address space 1. Sets the edge latency to `20 cycles`.
- Adds an llvm regression test for HB subtarget, testing expected schedule with loads from address space 1.

I think this more or less solves the non-blocking loads in LLVM. Next steps are to test this on real HB kernels and look for corner cases.

@sampsyo your suggested 'direct attack' worked great! A small question I have though is, isn't it more appropriate to change the "node latency" than "edge latency"? Because, in HB's case, irrespective of what the instruction dependent on remote load is, latency is 20 cycles. Wouldn't there be any other llvm modules that might be solely looking at "node latency" a.k.a [`SUnit`](https://llvm.org/doxygen/classllvm_1_1SUnit.html)'s latency field?